### PR TITLE
Fixed refull HP on metamorph

### DIFF
--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -67,21 +67,10 @@
         [/show_if]
 
         [command]
-            [store_unit]
-                [filter]
-                    id=$unit.id
-                [/filter]
-                variable=start
-            [/store_unit]
             [if]
                 [have_unit]
                     type=EoMa_Water_Elemental,EoMa_Fire_Elemental,EoMa_Air_Elemental,EoMa_Earth_Elemental
                     x,y=$x1,$y1
-                    [not]
-                        [filter_wml]
-                            moves=0
-                        [/filter_wml]
-                    [/not]
                 [/have_unit]
                 [then]
                     {TRANSFORM_UNIT x,y=$x1,$y1 (EoMa_{ELEM}_Elemental)}
@@ -101,33 +90,15 @@
                     [/if]
                 [/else]
             [/if]
-            [store_unit]
+            [modify_unit]
                 [filter]
                     x,y=$x1,$y1
                 [/filter]
-                variable=modified
-            [/store_unit]
-            {VARIABLE modified.moves 0}
-            {IF_VAR modified.max_hitpoints less_than $unit.hitpoints (
-                [then]
-                    {VARIABLE modified.hitpoints $modified.max_hitpoints}
-                [/then]
-                [else]
-                    #full heal
-                    {IF_VAR unit.hitpoints greater_than_equal_to $start.max_hitpoints (
-                        [then]
-                            {VARIABLE modified.hitpoints $modified.max_hitpoints}
-                        [/then]
-                    )}
-                [/else]
-            )}
-            [unstore_unit]
-                variable=modified
-                find_vacant=no
-            [/unstore_unit]
-            {MODIFY_UNIT x,y=$x1,$y1 upkeep loyal}
-            {CLEAR_VARIABLE start}
-            {CLEAR_VARIABLE modified}
+                [effect]
+                    apply_to=loyal
+                [/effect]
+                moves=0
+            [/modify_unit]
         [/command]
     [/set_menu_item]
 #enddef


### PR DESCRIPTION
Previously, the unit would recover its full HP with each transformation, which in practice is every turn, making it an invincible unit.

Now uses [transform_unit] default behaviour. If HP is higher than maximum, is reduced. If is lower, keeps the same HP. I think this default behaviour is the most balanced to avoid exploits.
In addition, everything is done with a shorter code.

This resolves  #16