### PR TITLE
Fix spawned dimensional gate with advancements

### DIFF
--- a/units/LastSummoner.cfg
+++ b/units/LastSummoner.cfg
@@ -1349,7 +1349,7 @@
 							ability=tlu_spawndgs
 						[/filter]
 					[/animate_unit]
-					{UNIT $side_number (EoMa_Dimensional_Gate_II) $mehirgateloc.x $mehirgateloc.y (moves,attacks_left,placement,passable,animate,upkeep=0,0,map,yes,yes,loyal)}
+					{UNIT $side_number (EoMa_Dimensional_Gate_II) $mehirgateloc.x $mehirgateloc.y (moves,attacks_left,placement,passable,animate,upkeep,advances_to=0,0,map,yes,yes,loyal,"")}
 				[/then]
 			)}
 		[/then]

--- a/units/Living_Gate.cfg
+++ b/units/Living_Gate.cfg
@@ -633,7 +633,7 @@
                             [/allied_with]
                             variable=tmp_living_gate_ally
                         [/store_side]
-                        {UNIT $tmp_living_gate_ally[0].side (EoMa_Dimensional_Gate_II) $lgloc.x $lgloc.y (moves,attacks_left,placement,passable,animate=0,0,map,yes,yes)}
+                        {UNIT $tmp_living_gate_ally[0].side (EoMa_Dimensional_Gate_II) $lgloc.x $lgloc.y (moves,attacks_left,placement,passable,animate,advances_to=0,0,map,yes,yes,"")}
                         {CLEAR_VARIABLE tmp_living_gate_ally}
                     [/then]
                 )}


### PR DESCRIPTION
If a dimensional gate is spawned by the Living Gate or by Mehir in his Last Summoner form, it spawns with the upgrades and experience available, as it should when playing vanilla Era of Magic. The campaign assumes that you can only advance by killing living units, so this way a living gate can level up without killing, just by fighting.
This fixes the issue and causes spawned living gates to spawn without advancements.

It's a very simple fix.