### PR TITLE
Elemental metamorph air stuck fix

### DIFF
--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -126,6 +126,7 @@
                 [/not]
             [/have_unit]
             [have_location]
+                x,y=$x1,$y1
                 [not]
                     terrain=Q*,*^Qov,Mv
                 [/not]

--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -127,7 +127,7 @@
             [/have_unit]
             [have_location]
                 [not]
-                    terrain=Q*
+                    terrain=Q*,*^Qov,Mv
                 [/not]
             [/have_location]
         [/show_if]

--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -103,11 +103,77 @@
     [/set_menu_item]
 #enddef
 
+#define METAMORPH_FIRE_NO_AIR ELEM TRANSFORM_MESSAGE IMAGE
+    [set_menu_item]
+        id=metamorph_{ELEM}
+        description={TRANSFORM_MESSAGE}
+        image={IMAGE}~SCALE(20,20)
+        [show_if]
+            [have_unit]
+                [not]
+                    type=EoMa_{ELEM}_Elemental,EoMa_{ELEM}_Avatar,EoMa_{ELEM}_God
+                [/not]
+                x,y=$x1,$y1
+                [filter_wml]
+                    [status]
+                        amulet_elem=yes
+                    [/status]
+                [/filter_wml]
+                [not]
+                    [filter_wml]
+                        moves=0
+                    [/filter_wml]
+                [/not]
+            [/have_unit]
+			[have_location]
+				[not]
+					terrain=Q*
+				[/not]
+			[/have_location]
+        [/show_if]
+
+        [command]
+            [if]
+                [have_unit]
+                    type=EoMa_Water_Elemental,EoMa_Fire_Elemental,EoMa_Air_Elemental,EoMa_Earth_Elemental
+                    x,y=$x1,$y1
+                [/have_unit]
+                [then]
+                    {TRANSFORM_UNIT x,y=$x1,$y1 (EoMa_{ELEM}_Elemental)}
+                [/then]
+                [else]
+                    [if]
+                        [have_unit]
+                            type=EoMa_Water_Avatar,EoMa_Fire_Avatar,EoMa_Air_Avatar,EoMa_Earth_Avatar
+                            x,y=$x1,$y1
+                        [/have_unit]
+                        [then]
+                            {TRANSFORM_UNIT x,y=$x1,$y1 (EoMa_{ELEM}_Avatar)}
+                        [/then]
+                        [else]
+                            {TRANSFORM_UNIT x,y=$x1,$y1 (EoMa_{ELEM}_God)}
+                        [/else]
+                    [/if]
+                [/else]
+            [/if]
+            [modify_unit]
+                [filter]
+                    x,y=$x1,$y1
+                [/filter]
+                [effect]
+                    apply_to=loyal
+                [/effect]
+                moves=0
+            [/modify_unit]
+        [/command]
+    [/set_menu_item]
+#enddef
+
 #define METAMORPH_ALL
     {METAMORPH_FIRE Fire (_ "Turn into fire") attacks/fire-blast.png}
-    {METAMORPH_FIRE Water (_ "Turn into water") attacks/waterspray.png}
+    {METAMORPH_FIRE_NO_AIR Water (_ "Turn into water") attacks/waterspray.png}
     {METAMORPH_FIRE Air (_ "Turn into air") attacks/eyeofstorm.png}
-    {METAMORPH_FIRE Earth (_ "Turn into earth") attacks/landmass.png}
+    {METAMORPH_FIRE_NO_AIR Earth (_ "Turn into earth") attacks/landmass.png}
 #enddef
 
 #define ABILITY_MEDITATION

--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -125,11 +125,11 @@
                     [/filter_wml]
                 [/not]
             [/have_unit]
-			[have_location]
-				[not]
-					terrain=Q*,*^Qov,Mv
-				[/not]
-			[/have_location]
+            [have_location]
+                [not]
+                    terrain=Q*
+                [/not]
+            [/have_location]
         [/show_if]
 
         [command]

--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -127,7 +127,7 @@
             [/have_unit]
 			[have_location]
 				[not]
-					terrain=Q*
+					terrain=Q*,*^Qov,Mv
 				[/not]
 			[/have_location]
         [/show_if]


### PR DESCRIPTION
This is a test fix to prevent a metamorph from switching into a unit that can't move. It's not a huge bug, since the next turn it can restore another flying form, but it adds realism, since Dimensional Portals also have a filter to prevent this.

**Draft until well tested.**