### PR TITLE
Balance turns and gold in S16-S19

### DIFF
--- a/scenarios/16_Defense_of_Saffaros.cfg
+++ b/scenarios/16_Defense_of_Saffaros.cfg
@@ -4,8 +4,8 @@
     next_scenario=17_Siege_of_Kharos
     name= _  "Defense of Saffaros"
     map_data="{~add-ons/To_Lands_Unknown/maps/16_Defense_of_Saffaros.map}"
-    turns=39
-    {TURNS 42 38 34}
+    turns=34
+    {TURNS 38 33 28}
     victory_when_enemies_defeated=no
     current_time=5
 

--- a/scenarios/17_Siege_of_Kharos.cfg
+++ b/scenarios/17_Siege_of_Kharos.cfg
@@ -4,7 +4,7 @@
     next_scenario=18_The_City_of_Light
     name= _ "Siege of Kharos"
     map_data="{~add-ons/To_Lands_Unknown/maps/17_Siege_of_Kharos.map}"
-    {TURNS 60 50 40}
+    {TURNS 42 36 30}
     victory_when_enemies_defeated=no
 
     {SCENARIO_MUSIC Overlive.ogg}

--- a/scenarios/19_Sky_Kingdom.cfg
+++ b/scenarios/19_Sky_Kingdom.cfg
@@ -27,8 +27,9 @@
         canrecruit=yes
         profile=portraits/mehir-leader.png
 
-        {GOLD 500 400 300}
-        {INCOME 10 5 3}
+        {GOLD 550 450 350}
+        {INCOME 15 10 5}
+        village_support=6
 
         recruit=EoMa_Water_Elemental,EoMa_Fire_Elemental,EoMa_Water_Avatar,EoMa_Fire_Avatar,EoMa_Rhami,EoMa_RhamiDatu,EoMa_RhamiKai,EoMa_Jinn
     [/side]
@@ -538,8 +539,9 @@
                 {TURNS_RUN_OUT}
                 [gold_carryover]
                     bonus=no
-                    carryover_percentage=40
+                    carryover_percentage=5
                 [/gold_carryover]
+                note= _ "Each captured village will provide support for two Level 3 units during this scenario."
             [/objectives]
         )}
     [/event]
@@ -1295,8 +1297,9 @@
                 {TURNS_RUN_OUT}
                 [gold_carryover]
                     bonus=no
-                    carryover_percentage=40
+                    carryover_percentage=5
                 [/gold_carryover]
+                note= _ "Each captured village will provide support for two Level 3 units during this scenario.
             [/objectives]
         ) ()}
     [/event]
@@ -1455,7 +1458,7 @@
 
         [endlevel]
             result=victory
-            {NEW_GOLD_CARRYOVER 40}
+            {NEW_GOLD_CARRYOVER 5}
             bonus=no
             carryover_report=yes
             linger_mode=no


### PR DESCRIPTION
1. There are way too many turns in Defense of Saffaros and Siege of Kharos.
2. Huge negative gold in Sky Kingdom is bad UX. This update also adds an incentive for management of the recall list and economy, in 1-3 extra recalls for S22 North Pole (probably the hardest scenario in the entire campaign).