### PR TITLE
Prevent ultimate circle stacking with circleres

### DIFF
--- a/scenarios/21_Skydock.cfg
+++ b/scenarios/21_Skydock.cfg
@@ -230,6 +230,22 @@
         {ADVANCE_UNIT id=Mehir "TLU_The_Last_Summoner"}
         {MODIFY_UNIT id=Mehir profile "portraits/mehir-last.png"}
         {MODIFY_UNIT id=Mehir experience $mehirvar.experience}
+        [object]
+            silent=yes
+            duration=forever
+            [filter]
+                id=Mehir
+            [/filter]
+            [effect]
+                apply_to=remove_ability
+                [abilities]
+                    {ABILITY_EOMA_CIRCLERES}
+                    [dummy]
+                        id=circleres_bonus
+                    [/dummy]
+                [/abilities]
+            [/effect]
+        [/object]
         {CLEAR_VARIABLE mehirvar}
 
         [store_unit]

--- a/scenarios/21_Skydock.cfg
+++ b/scenarios/21_Skydock.cfg
@@ -196,14 +196,32 @@
         [/fire_event]
     [/event]
 
-#define AMLA_REWARD NAME
+#define AMLA_REWARD ABILITY_NAME ABILITY_MACRO
     [if]
         [have_unit]
             id=Mehir
-            ability={NAME}_bonus
+            ability={ABILITY_NAME}
         [/have_unit]
         [then]
+            [object]
+                silent=yes
+                duration=forever
+                [filter]
+                    id=Mehir
+                [/filter]
+                [effect]
+                    apply_to=remove_ability
+                    [abilities]
+                        {ABILITY_MACRO}
+                        [dummy]
+                            id={ABILITY_NAME}
+                        [/dummy]
+                    [/abilities]
+                [/effect]
+            [/object]
+
             [set_variable]
+                # Calculation and possible advancement delayed til next scenario
                 name=expbonus
                 add=80
             [/set_variable]
@@ -220,7 +238,7 @@
     [event]
         name=transformation
 
-        {AMLA_REWARD circleres}
+        {AMLA_REWARD circleres_bonus {ABILITY_EOMA_CIRCLERES}}
         [store_unit]
             [filter]
                 id=Mehir
@@ -230,22 +248,6 @@
         {ADVANCE_UNIT id=Mehir "TLU_The_Last_Summoner"}
         {MODIFY_UNIT id=Mehir profile "portraits/mehir-last.png"}
         {MODIFY_UNIT id=Mehir experience $mehirvar.experience}
-        [object]
-            silent=yes
-            duration=forever
-            [filter]
-                id=Mehir
-            [/filter]
-            [effect]
-                apply_to=remove_ability
-                [abilities]
-                    {ABILITY_EOMA_CIRCLERES}
-                    [dummy]
-                        id=circleres_bonus
-                    [/dummy]
-                [/abilities]
-            [/effect]
-        [/object]
         {CLEAR_VARIABLE mehirvar}
 
         [store_unit]

--- a/units/LastSummoner.cfg
+++ b/units/LastSummoner.cfg
@@ -262,6 +262,22 @@
             affect_allies=yes
             [affect_adjacent]
                 adjacent=n,ne,se,s,sw,nw
+                [filter]
+                    [not]
+                        [filter_adjacent]
+                            ability=eoma_circleres
+                            is_enemy=no
+                        [/filter_adjacent]
+                        [or]
+                            ability=eoma_magicabsorb
+                        [/or]
+                        [or]
+                            [filter_adjacent]
+                                ability=eoma_magicabsorb
+                            [/filter_adjacent]
+                        [/or]
+                    [/not]
+                [/filter]
             [/affect_adjacent]
         [/resistance]
     [/abilities]


### PR DESCRIPTION
When Mehir got circle of resistance AMLA, this removes third point of #30.

> Adjacent allies get +20% resistances from the UC ability (further).

Afterwards, Mehir himself still benefits from a +20% resistance bonus provided by the AMLA which Heavy Summoners don't enjoy. Given that he's compensated only 80 XP, is this the intended behavior?