### PR TITLE
Remove redundant error-prone WML from Kamikaze Drone

### DIFF
--- a/units/Kamikaze_Drone.cfg
+++ b/units/Kamikaze_Drone.cfg
@@ -20,31 +20,8 @@
             image_mod=~FL(horiz)
         [/frame]
     [/movement_anim]
-    [movement_costs]
-        hills=2
-        mountains=3
-        cave=1
-    [/movement_costs]
-    [resistance]
-        blade=70
-        pierce=70
-        impact=80
-        fire=100
-        cold=90
-        arcane=70
-    [/resistance]
-    [defense]
-        mountains=40
-        hills=50
-    [/defense]
     [attack]
-        name=legs
-        description=_"legs"
-        icon=attacks/pike.png
-        type=pierce
-        range=melee
-        damage=3
-        number=4
+        #legs
     [/attack]
     [attack]
         name=kamikazedrone
@@ -61,7 +38,7 @@
     [abilities]
         {ABILITY_EOMA_UPGRADABLE}
         {ABILITY_SKIRMISHER}
-        {ABILITY_EOMA_DRONEKAMIKAZE}
+        {ABILITY_EOMA_DRONEKAMIKAZE} #dummy
     [/abilities]
     [attack_anim]
         [filter_attack]
@@ -94,37 +71,4 @@
         [/else]
     [/attack_anim]
     {KAMIKAZE_ANIM kamikazedrone "units/runemasters-machines/drone-move1.png~BLIT(units/runemasters-machines/drone-upgrade-kamikaze.png)"}
-    [event]
-        name=attack
-        first_time_only=no
-        [filter_attack]
-            name=kamikazedrone
-        [/filter_attack]
-        [modify_unit]
-            [filter]
-                x,y=$x1,$y1
-            [/filter]
-            [object]
-                silent=yes
-                [effect]
-                    apply_to=image_mod
-                    replace="~BLIT(misc/blank-hex.png)"
-                [/effect]
-                [filter]
-                    x,y=$x1,$y1
-                [/filter]
-            [/object]
-        [/modify_unit]
-    [/event]
-    [event]
-        name=attack end
-        first_time_only=no
-        [filter_attack]
-            name=kamikazedrone
-        [/filter_attack]
-        [kill]
-            x,y=$x1,$y1
-            animate=no
-        [/kill]
-    [/event]
 [/unit_type]


### PR DESCRIPTION
Related: https://github.com/inferno8/wesnoth-To_Lands_Unknown/issues/33, https://github.com/inferno8/wesnoth-Era_of_Magic/issues/44

It also updates the resistance of Kamikaze Drones to match Era of Magic updates.