### PR TITLE
Actually import AMLA penalties for all scenarios

### DIFF
--- a/macros/amla.cfg
+++ b/macros/amla.cfg
@@ -120,7 +120,7 @@
             increase=10%
         [/effect]
         [effect]
-            # 114% XP in AMLA_MEHIR_PENALTIES
+            # 114% XP in main-macros.cfg#AMLA_MEHIR_PENALTIES
             apply_to=movement
             increase=40
         [/effect]
@@ -259,7 +259,7 @@
             increase=14%
         [/effect]
         [effect]
-            # 114% XP in AMLA_MEHIR_PENALTIES
+            # 114% XP in main-macros.cfg#AMLA_MEHIR_PENALTIES
             apply_to=movement
             increase=80
         [/effect]
@@ -568,102 +568,6 @@
             remove=slowed
         [/effect]
     [/advancement]
-#enddef
-
-#define AMLA_XP_PENALTY_TEMP INDEX AMOUNT
-    [case]
-        value={INDEX}
-        [object]
-            id=mehir_amla_penalty_{INDEX}
-            [filter]
-                id=$unit.id
-            [/filter]
-            [effect]
-                apply_to=max_experience
-                increase={AMOUNT}
-            [/effect]
-        [/object]
-    [/case]
-#enddef
-
-#define AMLA_HP_PENALTY_TEMP INDEX AMOUNT
-    [case]
-        value={INDEX}
-        [object]
-            id=mehir_amla_penalty_{INDEX}
-            [filter]
-                id=$unit.id
-            [/filter]
-            [effect]
-                apply_to=hitpoints
-                increase_total=-{AMOUNT}
-            [/effect]
-        [/object]
-    [/case]
-#enddef
-
-#define AMLA_MEHIR_PENALTIES
-    [event]
-        name=post advance
-        first_time_only=no
-        [filter]
-            id=Mehir
-        [/filter]
-
-        {VARIABLE amla_index "$($unit.max_moves / 10)"}
-        {IF_UNIT_INTERSECT (x,y=$x1,$y1) (type=TLU_Mehir_Guard,TLU_Mehir_Commander) (
-            [switch]
-                variable=amla_index
-                # Numbers only need to remain in sync with [effect] (10 times CASE = MP),
-                # and with the [for] block below.
-                {AMLA_XP_PENALTY_TEMP 1 15%} # scimitar
-                {AMLA_XP_PENALTY_TEMP 2 15%} # hammer
-                {AMLA_XP_PENALTY_TEMP 3 15%} # magic
-
-                # 110%*114%=125%
-                {AMLA_XP_PENALTY_TEMP 4 14%} # scimitar strike (+10% permanent)
-                {AMLA_HP_PENALTY_TEMP 5 10%} # movement
-                {AMLA_XP_PENALTY_TEMP 6 15%} # meditation
-                {AMLA_XP_PENALTY_TEMP 7 15%} # jinn philosophy
-                {AMLA_XP_PENALTY_TEMP 8 10%} # doom scrolling (+14% permanent)
-                {AMLA_XP_PENALTY_TEMP 9 15%} # fast summon
-                {AMLA_XP_PENALTY_TEMP 10 10%} # veteran summons (+14% permanent)
-                {AMLA_XP_PENALTY_TEMP 11 14%} # give to the poor (+10% permanent)
-                {AMLA_XP_PENALTY_TEMP 12 10%} # take from the rich (+14% permanent)
-                {AMLA_XP_PENALTY_TEMP 13 10%} # hp
-            [/switch]
-        ) (
-            {IF_UNIT_INTERSECT (x,y=$x1,$y1) (type=TLU_Mehir_Leader) (
-                [for]
-                    variable=i
-                    start=1
-                    end=13 # Keep in sync with above switch.
-                    [do]
-                        [remove_object]
-                            id=Mehir
-                            object_id="mehir_amla_penalty_$i"
-                        [/remove_object]
-                    [/do]
-                [/for]
-            ) ()}
-        )}
-        {VARIABLE expected_moves "$($unit.max_moves % 10)"}
-        {IF_VAR amla_index not_equals 0 (
-            [then]
-                [object]
-                    [filter]
-                        x,y=$x1,$y1
-                    [/filter]
-                    [effect]
-                        apply_to=movement
-                        set="$expected_moves"
-                    [/effect]
-                [/object]
-            [/then]
-        )}
-        {CLEAR_VARIABLE amla_index}
-        {CLEAR_VARIABLE expected_moves}
-    [/event]
 #enddef
 
 #define MEHIR_GUARD_AMLAS

--- a/main-macros.cfg
+++ b/main-macros.cfg
@@ -1,5 +1,20 @@
 #textdomain wesnoth-To_Lands_Unknown
 
+#define IF_UNIT_INTERSECT FIRST SECOND ACTION_INTERSECTS ACTION_EMPTY
+    [if]
+        [have_unit]
+            {FIRST}
+            {SECOND}
+        [/have_unit]
+        [then]
+            {ACTION_INTERSECTS}
+        [/then]
+        [else]
+            {ACTION_EMPTY}
+        [/else]
+    [/if]
+#enddef
+
 #define MEDITATION_EVENT ABILITY AMOUNT
     [event]
         name=side 1 turn end
@@ -211,6 +226,102 @@
     [/event]
 #enddef
 
+#define AMLA_XP_PENALTY_TEMP INDEX AMOUNT
+    [case]
+        value={INDEX}
+        [object]
+            id=mehir_amla_penalty_{INDEX}
+            [filter]
+                id=$unit.id
+            [/filter]
+            [effect]
+                apply_to=max_experience
+                increase={AMOUNT}
+            [/effect]
+        [/object]
+    [/case]
+#enddef
+
+#define AMLA_HP_PENALTY_TEMP INDEX AMOUNT
+    [case]
+        value={INDEX}
+        [object]
+            id=mehir_amla_penalty_{INDEX}
+            [filter]
+                id=$unit.id
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                increase_total=-{AMOUNT}
+            [/effect]
+        [/object]
+    [/case]
+#enddef
+
+#define AMLA_MEHIR_PENALTIES
+    [event]
+        name=post advance
+        first_time_only=no
+        [filter]
+            id=Mehir
+        [/filter]
+
+        {VARIABLE amla_index "$($unit.max_moves / 10)"}
+        {IF_UNIT_INTERSECT (x,y=$x1,$y1) (type=TLU_Mehir_Guard,TLU_Mehir_Commander) (
+            [switch]
+                variable=amla_index
+                # Numbers only need to remain in sync with [effect] (10 times CASE = MP),
+                # and with the [for] block below.
+                {AMLA_XP_PENALTY_TEMP 1 15%} # scimitar
+                {AMLA_XP_PENALTY_TEMP 2 15%} # hammer
+                {AMLA_XP_PENALTY_TEMP 3 15%} # magic
+
+                # 110%*114%=125%
+                {AMLA_XP_PENALTY_TEMP 4 14%} # scimitar strike (+10% permanent)
+                {AMLA_HP_PENALTY_TEMP 5 10%} # movement
+                {AMLA_XP_PENALTY_TEMP 6 15%} # meditation
+                {AMLA_XP_PENALTY_TEMP 7 15%} # jinn philosophy
+                {AMLA_XP_PENALTY_TEMP 8 10%} # doom scrolling (+14% permanent)
+                {AMLA_XP_PENALTY_TEMP 9 15%} # fast summon
+                {AMLA_XP_PENALTY_TEMP 10 10%} # veteran summons (+14% permanent)
+                {AMLA_XP_PENALTY_TEMP 11 14%} # give to the poor (+10% permanent)
+                {AMLA_XP_PENALTY_TEMP 12 10%} # take from the rich (+14% permanent)
+                {AMLA_XP_PENALTY_TEMP 13 10%} # hp
+            [/switch]
+        ) (
+            {IF_UNIT_INTERSECT (x,y=$x1,$y1) (type=TLU_Mehir_Leader) (
+                [for]
+                    variable=i
+                    start=1
+                    end=13 # Keep in sync with above switch.
+                    [do]
+                        [remove_object]
+                            id=Mehir
+                            object_id="mehir_amla_penalty_$i"
+                        [/remove_object]
+                    [/do]
+                [/for]
+            ) ()}
+        )}
+        {VARIABLE expected_moves "$($unit.max_moves % 10)"}
+        {IF_VAR amla_index not_equals 0 (
+            [then]
+                [object]
+                    [filter]
+                        x,y=$x1,$y1
+                    [/filter]
+                    [effect]
+                        apply_to=movement
+                        set="$expected_moves"
+                    [/effect]
+                [/object]
+            [/then]
+        )}
+        {CLEAR_VARIABLE amla_index}
+        {CLEAR_VARIABLE expected_moves}
+    [/event]
+#enddef
+
 #define EVENTS_MEHIR_AMLA
     [event]
         name=post summon
@@ -238,6 +349,7 @@
         {CLEAR_VARIABLE summoned}
     [/event]
 
+    {AMLA_MEHIR_PENALTIES}
     {MEDITATION_EVENT meditation 1}
     {MEDITATION_EVENT jinn_philosophy 3}
     # {EVENTS_MEHIR_GOLD_AMLA}


### PR DESCRIPTION
I included the macro only in one scenario of my local campaign copy, so I missed this.
