### PR TITLE
S07: Replenish Mehir's moves after promotion

### DIFF
--- a/scenarios/07_Dome_of_Elements.cfg
+++ b/scenarios/07_Dome_of_Elements.cfg
@@ -226,7 +226,11 @@
             speaker=Instructor
             message= _ "Now you have to step in."
         [/message]
-        {MOVE_UNIT id=Mehir 14 10}
+        [move_unit]
+            id=Mehir
+            to_x,to_y=14,10
+            fire_event=yes
+        [/move_unit]
         [store_unit]
             [filter]
                 id=Mehir


### PR DESCRIPTION
So that the summon menu shows up immediately rather than after manual move&replenish.