### PR TITLE
Allow Last Summoner to summon elementals

### DIFF
--- a/units/LastSummoner.cfg
+++ b/units/LastSummoner.cfg
@@ -228,6 +228,12 @@
                 [/filter]
             [/affect_adjacent]
         [/resistance]
+        {ABILITY_EOMA_SUMMON mehirlast (
+            {SUMMON_MENU_ITEM 6_3_1 ( _ "Summon Fire Elemental") 7 (TLU_The_Last_Summoner) (EoMa_Fire_Elemental)}
+            {SUMMON_MENU_ITEM 6_3_2 ( _ "Summon Water Elemental") 6 (TLU_The_Last_Summoner) (EoMa_Water_Elemental)}
+            {SUMMON_MENU_ITEM 6_3_3 ( _ "Summon Air Elemental") 9 (TLU_The_Last_Summoner) (EoMa_Air_Elemental)}
+            {SUMMON_MENU_ITEM 6_3_4 ( _ "Summon Earth Elemental") 8 (TLU_The_Last_Summoner) (EoMa_Earth_Elemental)}
+        )}
     [/abilities]
     [standing_anim]
         start_time=0


### PR DESCRIPTION
Fixes #51. Requires https://github.com/inferno8/wesnoth-Era_of_Magic/pull/47.

Currently using the same gold costs as Summons Masters.