### PR TITLE
Explicitly include EoMa resources for units.wesnoth.org

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -96,6 +96,11 @@ This is the story of Mehir, the Summoner, and his journey to lands unknown."+"
         path=data/add-ons/To_Lands_Unknown_Resources_2
     [/binary_path]
 #endif
+#ifdef __WMLUNITS__
+    [binary_path]
+        path=data/add-ons/Era_of_Magic_Resources
+    [/binary_path]
+#endif
 #endif
 #ifdef EDITOR
     {~add-ons/To_Lands_Unknown/macros/terrain_base.cfg}


### PR DESCRIPTION
https://units.wesnoth.org seems to fail to resolve the [image resources](https://units.wesnoth.org/1.16/To_Lands_Unknown/en_US/To_Lands_Unknown.html) of EoMa units. This is an attempt to let the script know where to search them.
