### PR TITLE
Revert "Explicitly include EoMa resources for units.wesnoth.org"

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -96,11 +96,6 @@ This is the story of Mehir, the Summoner, and his journey to lands unknown."+"
         path=data/add-ons/To_Lands_Unknown_Resources_2
     [/binary_path]
 #endif
-#ifdef __WMLUNITS__
-    [binary_path]
-        path=data/add-ons/Era_of_Magic_Resources
-    [/binary_path]
-#endif
 #endif
 #ifdef EDITOR
     {~add-ons/To_Lands_Unknown/macros/terrain_base.cfg}


### PR DESCRIPTION
Proper fix in [#7603](https://github.com/wesnoth/wesnoth/pull/7603)
