### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _info.cfg
 translations/**/*.po~
+**/*.cfg-bak

--- a/main-macros.cfg
+++ b/main-macros.cfg
@@ -441,7 +441,7 @@
                             image=portraits/narrator.png
                             message= _ "You have managed to acquire a 'Dimensional Gate'. These special units can be transformed into real magical beings by consuming souls of living creatures. You will learn more about the usage of Dimensional Gates later in the story.
 
-NOTE: When used right, a Dimensional Gate may be used to summon a Jinni, but Mehir has not been experienced enough to own such powerful unit yet. Feel free to summon other beings though or you can stack these gates for later use."
+NOTE: When used right, a Dimensional Gate may be used to summon units you may not recruit, such as powerful yet expensive Jinni. You may also choose to stack these gates for later use."
                         [/message]
                         {VARIABLE player_banished_creature yes}
                     [/else]

--- a/scenarios/06_Fire_Canyon.cfg
+++ b/scenarios/06_Fire_Canyon.cfg
@@ -1479,7 +1479,7 @@
         {BADASS_MODE_CHANGE () (
             [if]
                 [have_unit]
-                    id=Bleader
+                    id=BLeader
                 [/have_unit]
                 [then]
                     [if]

--- a/scenarios/10_Chaos.cfg
+++ b/scenarios/10_Chaos.cfg
@@ -2097,7 +2097,7 @@
                         #the portal has been closed
                         [message]
                             speaker=unit
-                            message= _ "My Master, we need to eliminate all the remaining enemies before we leave this place. Because our camp has been destroyed I suggest you to summon reinforcements directly from the Abyss using your personal megacircle."
+                            message= _ "My Master, we need to eliminate all the remaining enemies before we leave this place. Because our camp has been destroyed I suggest you to summon reinforcements directly from the Abyss using your personal circle."
                         [/message]
                     [/else]
                 )}

--- a/scenarios/12_Siege_of_Mag-Magar.cfg
+++ b/scenarios/12_Siege_of_Mag-Magar.cfg
@@ -865,12 +865,6 @@
         [filter]
             id=Matriarch2
         [/filter]
-        [filter_second]
-            side=1,5
-            [not]
-                type=TLU_Living_Gate
-            [/not]
-        [/filter_second]
         [message]
             speaker=unit
             message= _ "This mission is a complete disaster. I told Almathis many times that we should finish off the pathetic sun-lovers first, but that arrogant fool wouldn't listen to my advice..."
@@ -966,11 +960,7 @@
     [event]
         name=attack
         [filter]
-            [not]
-                [filter_wml]
-                    flies=yes
-                [/filter_wml]
-            [/not]
+            formula=not self.flying
         [/filter]
         [filter_second]
             id=Malib
@@ -983,11 +973,7 @@
     [event]
         name=attack end
         [filter]
-            [not]
-                [filter_wml]
-                    flies=yes
-                [/filter_wml]
-            [/not]
+            formula=not self.flying
         [/filter]
         [filter]
             canrecruit=no

--- a/scenarios/15_Abyssal_Rebellion.cfg
+++ b/scenarios/15_Abyssal_Rebellion.cfg
@@ -1930,7 +1930,7 @@ Elementals and level 2-3 blue beings like Great Jinn, Rhami'kai and Ho'rhami wil
             [then]
                 [message]
                     speaker=unit
-                    message= _ "My Master, in my vision I am seeing our Holy Rashti'rhami going rouge after conversation with the enemy leader! And the worst part is, this happens in all possible futures!"
+                    message= _ "My Master, in my vision I am seeing our Holy Rashti'rhami going rogue after conversation with the enemy leader! And the worst part is, this happens in all possible futures!"
                 [/message]
                 {BADASS_MODE_CHANGE (
                     [message]
@@ -1969,7 +1969,7 @@ Elementals and level 2-3 blue beings like Great Jinn, Rhami'kai and Ho'rhami wil
                 {BADASS_MODE_CHANGE () (
                     [message]
                         speaker=unit
-                        message= _ "My Master, we need to hurry. Our Holy Rashti'rhami has been comeplety destabilized and won't survive much longer in her current state!"
+                        message= _ "My Master, we need to hurry. Our Holy Rashti'rhami has been completely destabilized and won't survive much longer in her current state!"
                     [/message]
                     [message]
                         image="portraits/mehir-commander-angry.png{TLU_MEHIR_PORTRAIT_ELEMENTS}"

--- a/units/Living_Gate.cfg
+++ b/units/Living_Gate.cfg
@@ -474,11 +474,7 @@
             type=TLU_Living_Gate
         [/filter]
         [filter_second]
-            [not]
-                [filter_wml]
-                    flies=true
-                [/filter_wml]
-            [/not]
+            formula=not self.flying
         [/filter_second]
 
         [object]
@@ -536,11 +532,7 @@
         first_time_only=no
 
         [filter]
-            [not]
-                [filter_wml]
-                    flies=true
-                [/filter_wml]
-            [/not]
+            formula=not self.flying
         [/filter]
         [filter_second]
             type=TLU_Living_Gate

--- a/units/Malib.cfg
+++ b/units/Malib.cfg
@@ -9,7 +9,7 @@
 
     hitpoints=70
     movement_type=smallfoot
-    flies=true
+    flying=yes
     movement=5
     experience=200
     level=4
@@ -70,11 +70,7 @@ All around the summons master, miracles occur, and ruin is wrought."
         name=attack
         first_time_only=no
         [filter]
-            [not]
-                [filter_wml]
-                    flies=yes
-                [/filter_wml]
-            [/not]
+            formula=not self.flying
         [/filter]
         [filter_second]
             type=TLU_Malib


### PR DESCRIPTION
From [wiki/SingleUnitWML](https://wiki.wesnoth.org/SingleUnitWML)

> In SingleUnitWML, this attribute has been called flying since it was added in 1.11.2, it was never called 'flies'.

Also note that in S12, Anaraclya (EoMa_Cold_Matriarch) is a flying unit, so she cannot be assassinated by the Living Gate.