### PR TITLE
Fix most wmllint warnings

### DIFF
--- a/dependency-utils.cfg
+++ b/dependency-utils.cfg
@@ -14,19 +14,25 @@
 #enddef
 #endif
 
+#wmllint: markcheck off
 #ifndef HAVE_ERA_OF_MAGIC
 #define HAVE_ERA_OF_MAGIC_STATUS
     "
 <small><span color='red'><b>!</b></span> <span color='#888'>"+_"The required add-on “<i>Era of Magic</i>” is currently <b>not</b> installed."+"</span></small>" #enddef
+#wmllint: markcheck on
+
 #else
 #define HAVE_ERA_OF_MAGIC_STATUS
     "" #enddef
 #endif
 
+#wmllint: markcheck off
 #ifndef TLU_HAVE_IMAGES
 #define TLU_HAVE_IMAGES_STATUS
     "
 <small><span color='red'><b>!</b></span> <span color='#888'>"+_"The required add-on “<i>To Lands Unknown: Resources</i>” is currently <b>not</b> installed."+"</span></small>" #enddef
+#wmllint: markcheck on
+
 #else
 #define TLU_HAVE_IMAGES_STATUS
     "" #enddef

--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -1,6 +1,7 @@
 #textdomain wesnoth-To_Lands_Unknown
 
 #define ABILITY_AMULET_METAMORPH
+    # wmllint: unbalanced-on
     # wmlxgettext: [abilities]
     [dummy]
         id=metamorph
@@ -40,6 +41,7 @@
 [/event]
 [+abilities]
     # wmlxgettext: [/abilities]
+    # wmllint: unbalanced-off
 #enddef
 
 #define METAMORPH_FIRE ELEM TRANSFORM_MESSAGE IMAGE
@@ -228,12 +230,14 @@
 #enddef
 
 #define ABILITY_MEDITATION
+    # wmllint: unbalanced-on
     # wmlxgettext: [abilities]
     [dummy]
         id=meditation
         name= _ "meditation"
         description=_ "This unit gains 1 point of experience at the end of his side's turn without move/attack/summon."
     [/dummy] # wmlxgettext: [/abilities]
+    # wmllint: unbalanced-off
 #enddef
 
 #define ABILITY_JINN_PHILOSOPHY

--- a/macros/macros.cfg
+++ b/macros/macros.cfg
@@ -1380,6 +1380,10 @@
     [/if]
 #enddef
 
+#wmllint: who RECALL_RASHTI is Rashti
+#wmllint: who RECALL_RASHTI_AT is Rashti
+#wmllint: who RECALL_TRUE_RASHTI is Rashti
+
 #define RASHTICIRCLE COLOR DURATION
     circle_start_time=-400
     particle_start_time=-400

--- a/macros/storytxt.cfg
+++ b/macros/storytxt.cfg
@@ -278,12 +278,14 @@ _"Some animations may cause the game to crash. If it happens and you cannot prog
 #define STORYTXT_ALKAMIJA
     [story]
         [part]
-            story="<span color='#BCB088' font='26' weight='bold'>"+{TLU_WARNING1}+"</span>
+            story= "<span color='#BCB088' font='26' weight='bold'>" + #wmllint: ignore
+			{TLU_WARNING1}+"</span>
 <span color='#BCB088' font='18' weight='bold'>"+{TLU_WARNING2}+"</span>"
             background=story/planet.jpg
         [/part]
         [part]
-            story="<span color='#BCB088' font='26' weight='bold'>"+{TLU_WARNING3}+"</span>
+            story= "<span color='#BCB088' font='26' weight='bold'>" + #wmllint: ignore
+			{TLU_WARNING3}+"</span>
 <span color='#BCB088' font='18' weight='bold'>"+{TLU_WARNING4}+"</span>"
             background=story/planet.jpg
         [/part]
@@ -690,7 +692,8 @@ Meanwhile, Mehir entered the city, greeted by crowds of the citizens of Kharos, 
 #define STORYTXT_CUTSCENE
     [story]
         [part]
-            story="<span color='#BCB088' font='26' weight='bold'>"+{TLU_WARNING5}+"</span>
+            story= "<span color='#BCB088' font='26' weight='bold'>" + #wmllint: ignore
+			{TLU_WARNING5}+"</span>
 <span color='#BCB088' font='18' weight='bold'>"+{TLU_WARNING6}+"</span>"
             background=story/planet.jpg
         [/part]

--- a/scenarios/00_Prologue.cfg
+++ b/scenarios/00_Prologue.cfg
@@ -422,6 +422,7 @@
     [/message]
     {MOVE_UNIT id=enchanter 8 5}
     {UNIT 3 (EoMa_Air_Elemental) 9 6 (animate,facing=yes,sw)}
+    # wmllint: recognize enchanter
     {MOVE_UNIT id=enchanter 7 5}
     {FORCE_CHANCE_TO_HIT id=Mehir side=3 100 ()}
     {MOVE_UNIT id=Mehir 8 6}
@@ -484,6 +485,7 @@
 #enddef
 
 #define JINN_PROPHECY
+# wmllint: recognize wjinn
     [message]
         speaker=wjinn
         message= _ "Sure. Wait a minute, I need to focus..."

--- a/scenarios/01_Highest_Tiers.cfg
+++ b/scenarios/01_Highest_Tiers.cfg
@@ -420,7 +420,7 @@
             side=4
             ai_type=coward
             action=add
-            id=civilian_flee
+            ca_id=civilian_flee
             [filter]
             [/filter]
             distance=9

--- a/scenarios/02_Central_Palace.cfg
+++ b/scenarios/02_Central_Palace.cfg
@@ -416,7 +416,7 @@
         [/message]
         [message]
             speaker=Mehir
-            message= _ "Mehir, sir, Mehir ibn Hakim the elder, to be precise."
+            message= _ "Mehir, sir, Mehir ibn Hakim the elder, to be precise." #wmllint: noconvert
         [/message]
         [message]
             speaker=Sharif

--- a/scenarios/04_Southern_Nations.cfg
+++ b/scenarios/04_Southern_Nations.cfg
@@ -1,5 +1,6 @@
 #textdomain wesnoth-To_Lands_Unknown
 #define GIFT_MESSAGE
+# wmllint: recognize messenger
     [message]
         speaker=Mehir
         message= _ "Uhh... Hello? Who are you?"
@@ -451,6 +452,8 @@
         {UNIT 3 (EoMa_Barbarian) 21 18 (facing=sw
         generate_name=yes
         random_traits=yes)}
+
+        # wmllint: recognize Krog
     [/side]
 
     [side]
@@ -1181,6 +1184,7 @@
 #ifdef HARD
                 {UNIT 3 (EoMa_Roc_Master) 7 15 id,facing,animate=captain,se,yes}
 #endif
+                # wmllint: recognize captain
                 {UNIT 3 (EoMa_Roc_Rider) 6 14 (facing,animate=se,yes)}
                 {UNIT 3 (EoMa_Roc_Rider) 7 14 (facing,animate=se,yes)}
                 {UNIT 3 (EoMa_Roc_Rider) 5 14 (facing,animate=se,yes)}
@@ -1540,7 +1544,7 @@
         {BADASS_MODE_CHANGE (
             {VARIABLE spotted yes}
             [print]
-                text=" "
+                text=" " #wmllint: ignore
                 duration=300
             [/print]
             [unhide_unit]

--- a/scenarios/06_Fire_Canyon.cfg
+++ b/scenarios/06_Fire_Canyon.cfg
@@ -168,6 +168,7 @@
             random_traits=yes
             upkeep=loyal)}
         )}
+        # wmllint: recognize breaker
         {CAPTURE_VILLAGES 1 35 2 6}
         {CAPTURE_VILLAGES 2 7 14 8}
         {CAPTURE_VILLAGES 3 22 10 5}

--- a/scenarios/07_Dome_of_Elements.cfg
+++ b/scenarios/07_Dome_of_Elements.cfg
@@ -59,6 +59,7 @@
         {UNIT 2 (TLU_Elder) 5 9 (facing=se)}
         {UNIT 2 (TLU_Elder) 6 9 (facing=se)}
         {UNIT 2 (EoMa_HoRhami) 7 9 (facing=sw)}
+        # wmllint: recognize elder
     [/side]
 
     [side]
@@ -120,7 +121,7 @@
         {MODIFY_UNIT id=Instructor facing sw}
         [message]
             speaker=Instructor
-            message= _ "Excuse me, are you Mehir ibn Hakim the Elder, the one being promoted?"
+            message= _ "Excuse me, are you Mehir ibn Hakim the Elder, the one being promoted?" #wmllint: noconvert
         [/message]
         [message]
             speaker=Mehir
@@ -440,6 +441,8 @@
             #ladies
             {UNIT 2 (TLU_Citizen5) 10 12 (generate_name,id=yes,girl1)}
             {UNIT 2 (TLU_Citizen5) 8 12 (generate_name,id=yes,girl2)}
+            # wmllint: recognize girl1
+            # wmllint: recognize girl2
             {STORE_UNIT_VAR id=girl1 name girl1name}
             {STORE_UNIT_VAR id=girl2 name girl2name}
             {MOVE_UNIT id=girl1 11 10}

--- a/scenarios/08_Ka-gatta.cfg
+++ b/scenarios/08_Ka-gatta.cfg
@@ -241,7 +241,7 @@
             #making the spear guardian a bit of a boss:
             [modifications]
                 [trait]
-                    id=spearguardian
+                    id=spearguardian # wmllint: ignore
                     name= _ "spear guardian"
                     description= _ "This unit is blessed by the artifact it's guarding: the spear of the first Rhami'Kai."
                     [effect]
@@ -264,6 +264,7 @@
                 [/trait]
             [/modifications]
         )}
+        # wmllint: recognize SpearGuardian
     [/side]
 
     {STARTING_VILLAGES 1 5}
@@ -378,7 +379,7 @@
                 id=SpearGuardian
             [/filter]
 
-            id=spearguardian
+            ca_id=spearguardian
             return_x,return_y=4,14
         [/micro_ai]
     [/event]
@@ -693,7 +694,7 @@
             mode=append
 
             [value]
-                id=mscimitar
+                id=mscimitar # wmllint: ignore
                 name= _ "ancient scimitar"
                 description= _ "This unit holds a powerful scimitar.
 Effects:
@@ -802,7 +803,7 @@ Hit and Run +2 ability
             mode=append
 
             [value]
-                id=gcarpet
+                id=gcarpet # wmllint: ignore
                 name= _ "golden carpet"
                 description= _ "This unit flies on the ancient Golden Carpet.
 
@@ -897,7 +898,7 @@ Hit and Run +2 ability
             mode=append
 
             [value]
-                id=regenring
+                id=regenring # wmllint: ignore
                 name= _ "ring of regeneration"
                 description= _ "This unit wears the Ring of Regeneration.
 
@@ -951,7 +952,7 @@ Grants 50% fire resistance"
             mode=append
 
             [value]
-                id=dcloak
+                id=dcloak # wmllint: ignore
                 name= _ "desert cloak"
                 description= _ "This unit wears the famous Desert Cloak of ancients.
 
@@ -1031,7 +1032,7 @@ Decreases experience points needed for advancement by 25%"
             mode=append
 
             [value]
-                id=capofpower
+                id=capofpower # wmllint: ignore
                 name= _ "cap of power"
                 description= _ "This unit wears a magical cap, which enhances its magical power.
 
@@ -1076,6 +1077,7 @@ Decreases experience points needed for advancement by 25%"
             id=Ghost
             name=_"Samir"
         )}
+        # wmllint: recognize Ghost
 
         [message]
             speaker=Ghost
@@ -1362,7 +1364,7 @@ Decreases arcane resistance by 15%"
             mode=append
 
             [value]
-                id=cota
+                id=cota # wmllint: ignore
                 name= _ "ancient cuirass"
                 description= _ "This unit is wearing a powerful armor, which grants additional physical resistance, but also increases susceptibility to arcane damage.
 
@@ -1449,7 +1451,7 @@ Increases magical resistances by 10%"
             mode=append
 
             [value]
-                id=spearrhami
+                id=spearrhami # wmllint: ignore
                 name= _ "spear of rhami"
                 description= _ "This unit is holding a powerful spear of abysmal origin.
 
@@ -1598,7 +1600,7 @@ The unit can be recalled only 3 times. After that it dies for sure."
             mode=append
 
             [value]
-                id=collar
+                id=collar # wmllint: ignore
                 name= _ "collar"
                 description= _ "After death the unit is recalled back to the leader. Activates only 3 times."
             [/value]
@@ -1686,7 +1688,7 @@ The unit can be recalled only 3 times. After that it dies for sure."
             mode=append
 
             [value]
-                id=metamorph
+                id=metamorph # wmllint: ignore
                 name= _ "metamorph"
                 description= _ "This elemental wears the Amulet of Metamorph.
 
@@ -1770,7 +1772,7 @@ The unit becomes loyal."
             mode=append
 
             [value]
-                id=staffbanisher
+                id=staffbanisher # wmllint: ignore
                 name= _ "banishment staff"
                 description= _ "This unit is holding a powerful staff which once belonged to the first Master of Banishers.
 

--- a/scenarios/09_Goddess_of_All_Rhamis.cfg
+++ b/scenarios/09_Goddess_of_All_Rhamis.cfg
@@ -72,6 +72,7 @@
 #ifndef HARD
         {UNIT 2 (EoMa_Golem) 18 13 (facing,ai_special=se,guardian)}
         {UNIT 2 (EoMa_Mystic_Warrior) 20 13 (facing,ai_special,id=se,guardian,deputy)}
+        # wmllint: recognize deputy
         {UNIT 2 (EoMa_Golem) 22 13 (facing,ai_special=se,guardian)}
 #endif
 #ifdef HARD
@@ -196,6 +197,7 @@
             image="portraits/mehir-commander-angry.png{TLU_MEHIR_PORTRAIT_ELEMENTS}"
             message= _ "Everyone, cover Rashti'rhami, and secure the entrance!"
         [/message]
+        # wmllint: recognize SpearGuardian
         {BADASS_MODE_CHANGE (
             [if]
                 [have_unit]

--- a/scenarios/10_Chaos.cfg
+++ b/scenarios/10_Chaos.cfg
@@ -245,6 +245,7 @@
                 speaker=Mehir
                 message= _ "So here's our little coward. Ready to join your comrades in eternal life?"
             [/message]
+            # wmllint: recognize Mage
             [message]
                 speaker=Mage
                 message= _ "M-master Aerius! Th-this is him! Please, do something!"
@@ -599,7 +600,7 @@
     [message]
         speaker=Rashti
         image="portraits/rashti-dharma.png"
-        message=_ "Shakataraja Ramidajana Katarajan"
+        message=_ "Shakataraja Ramidajana Katarajan" #wmllint: noconvert
     [/message]
     {REDPORTAL}
     [if]
@@ -874,7 +875,7 @@
                             [/message]
                             [micro_ai]
                                 side=2
-                                id=Aerius_flee
+                                ca_id=Aerius_flee
                                 ai_type=goto
                                 action=add
                                 ca_id=Aerius

--- a/scenarios/11_Message.cfg
+++ b/scenarios/11_Message.cfg
@@ -220,6 +220,7 @@
         {MOVE_UNIT id=Rashti 23 15}
 
         {UNIT 4 (EoMa_HoRhami) 29 9 (facing,id=se,guardian1)}
+        # wmllint: recognize guardian1
 
         {MOVE_UNIT x,y=29,9 14 14}
 
@@ -267,6 +268,7 @@
         {MOVE_UNIT x,y=29,9 18 10}
 
         {UNIT 4 (EoMa_HoRhami) 29 9 (facing,id=sw,guardian2)}
+        # wmllint: recognize guardian2
 
         {MOVE_UNIT x,y=29,9 20 11}
 
@@ -463,7 +465,7 @@
             [/filter]
             ai_type=coward
             action=add
-            id=elder_flee
+            ca_id=elder_flee
             distance=6
         [/micro_ai]
 

--- a/scenarios/12_Siege_of_Mag-Magar.cfg
+++ b/scenarios/12_Siege_of_Mag-Magar.cfg
@@ -283,7 +283,7 @@
             side=6
             ai_type=coward
             action=add
-            id=civilian_flee
+            ca_id=civilian_flee
             [filter]
             [/filter]
             distance=5

--- a/scenarios/13_A_New_Leader.cfg
+++ b/scenarios/13_A_New_Leader.cfg
@@ -141,6 +141,7 @@
                 {UNITCOLOR orange})}
             [/else]
         )}
+        # wmllint: recognize Malib
     [/event]
 
     #start
@@ -230,6 +231,7 @@
         profile=portraits/sharif.png
         image_icon="portraits/sharif.png~CROP(160,20,130,130)~SCALE(72,72)"
         facing=sw
+        # wmllint: recognize Sharif
         {UNITCOLOR green})}
         {UNIT 2 (EoMa_Mystical_Jinn) 17 6 (facing=sw)}
         {UNIT 2 (EoMa_Mystical_Jinn) 9 6 (facing=se)}
@@ -241,16 +243,19 @@
         {IF_VAR jinn_and_rhami_dated equals yes (
             [then]
                 {UNIT 2 (EoMa_Wonderful_Jinn) 18 6 (
-                    id=wjinn
+                    id=wjinn # wmllint: ignore
                     name=_"Wonderful Jinn"
                 )}
                 {UNIT 2 (EoMa_HoRhami) 19 7 (
-                    id=gate_guardian
+                    id=gate_guardian # wmllint: ignore
                     name=_"Theivya"
                 )}
                 {UNIT 2 (EoMa_Dimensional_Gate) 19 6 (
-                    id=edward
+                    id=edward # wmllint: ignore
                 )}
+                # wmllint: recognize wjinn
+                # wmllint: recognize gate_guardian
+                # wmllint: recognize edward
             [/then]
             [else]
                 {UNIT 2 (EoMa_Wonderful_Jinn) 16 5 (facing=sw)}
@@ -305,6 +310,8 @@
 
         {UNIT 2 (TLU_Citizen5) 4 9 (generate_name,id=yes,girl1)}
         {UNIT 2 (TLU_Citizen5) 3 9 (generate_name,id=yes,girl2)}
+        # wmllint: recognize girl1
+        # wmllint: recognize girl2
 
         {FADE_IN}
         [delay]
@@ -333,7 +340,7 @@
         {MOVE_UNIT id=Mehir 13 10}
         [message]
             speaker=Elder
-            message= _ "By the power given to me by the High Council and in the name of all citizens of our country and the Abyss, Mehir ibn Hakim the elder, I grant you the authority over Tar-Tabar!"
+            message= _ "By the power given to me by the High Council and in the name of all citizens of our country and the Abyss, Mehir ibn Hakim the elder, I grant you the authority over Tar-Tabar!" #wmllint: noconvert
         [/message]
         [store_unit]
             [filter]
@@ -477,7 +484,7 @@
                     speaker=gate_guardian
                     message=_"An unusual name, but it does sound quite good. Very well."
                 [/message]
-                {MODIFY_UNIT id=edward name _"Edward"}#small inside joke, in one of ForestDragon's old eoma joke comics a dimensional gate adopted by a jinn and rhami had this name
+                {MODIFY_UNIT id=edward name _"Edward"} #small inside joke, in one of ForestDragon's old eoma joke comics a dimensional gate adopted by a jinn and rhami had this name
             [/then]
         )}
 

--- a/scenarios/14_Tar-Tabar.cfg
+++ b/scenarios/14_Tar-Tabar.cfg
@@ -138,7 +138,7 @@
                     mode=append
 
                     [value]
-                        id=staffbanisher
+                        id=staffbanisher # wmllint: ignore
                         name= _ "banishment staff"
                         description= _ "This unit is holding a powerful staff which once belonged to the first Master of Banishers.
 

--- a/scenarios/15_Abyssal_Rebellion.cfg
+++ b/scenarios/15_Abyssal_Rebellion.cfg
@@ -246,33 +246,34 @@
 
         [if]
             [have_unit]
-                id=Instructor
+                id=Instructor # wmllint: ignore
                 search_recall_list=yes
             [/have_unit]
             [then]
                 #recall Semir
                 [recall]
-                    id=Instructor
+                    id=Instructor # wmllint: ignore
                 [/recall]
                 {MODIFY_UNIT id=Instructor upkeep loyal}
                 [modify_unit]
                     [filter]
-                        id=Instructor
+                        id=Instructor # wmllint: ignore
                     [/filter]
                     {IS_LOYAL}
                 [/modify_unit]
-                {MODIFY_UNIT id=Instructor id Banisher}
+                {MODIFY_UNIT id=Instructor id Banisher} # wmllint: ignore
             [/then]
             [else]
                 #create Semir
                 {UNIT 1 (EoMa_Banisher) () () (placement=leader
                 {IS_LOYAL}
                 upkeep=loyal
-                id=Banisher
+                id=Banisher # wmllint: ignore
                 image_icon="portraits/summoners/banisher.png~CROP(131,10,130,130)~SCALE(72,72)"
                 unrenamable=yes
                 name= _ "Semir")}
             [/else]
+            # wmllint: recognize Banisher
         [/if]
 
         #predefined Reficul army
@@ -1712,6 +1713,7 @@ Elementals and level 2-3 blue beings like Great Jinn, Rhami'kai and Ho'rhami wil
             [/variable]
             [then]
                 {UNIT 1 (EoMa_Novice_Summoner) $x1 $y1 (id,animate,random_name,generate_traits=messenger,yes,yes,yes)}
+                # wmllint: recognize messenger
                 [message]
                     speaker=messenger
                     message= _ "Sir, we searched the rebel camp, and we found some belongings of their leader that you might want to have a look at."
@@ -1781,6 +1783,7 @@ Elementals and level 2-3 blue beings like Great Jinn, Rhami'kai and Ho'rhami wil
         image_icon="portraits/kharos/masterofsun.png~CROP(180,50,130,130)~SCALE(72,72)"
         id=Unknown
         name= _ "???")}
+        # wmllint: recognize Unknown
         [message]
             speaker=Unknown
             message= _ "*heavy breathing* ...I...finally...found...you..."

--- a/scenarios/16_Defense_of_Saffaros.cfg
+++ b/scenarios/16_Defense_of_Saffaros.cfg
@@ -408,6 +408,7 @@ Note that you can toggle these effects at any time during the scenario by using 
 
         {UNIT 2 (EoMa_White_Warrior) 33 32 (id=boy
         facing=se)}
+        # wmllint: recognize boy
 
         [message]
             id=boy
@@ -449,6 +450,7 @@ Note that you can toggle these effects at any time during the scenario by using 
 
         {UNIT 1 (EoMa_Master_of_Sun) 38 32 (id=Atiros
         image_icon="portraits/kharos/masterofsun.png~CROP(180,50,130,130)~SCALE(72,72)"
+        #wmllint: recognize Atiros
         {IS_HERO}
         upkeep=loyal
         name=Atiros)}
@@ -542,6 +544,7 @@ Note that you can toggle these effects at any time during the scenario by using 
         {REPLACE_SCENARIO_MUSIC siege_of_laurelmor.ogg}
         {UNIT 2 (EoMa_Cavalry_Archer) 49 21 (id=Rider2
         generate_name=yes)}
+        #wmllint: recognize Rider2
         {MOVE_UNIT id=Rider2 44 27}
         [message]
             speaker=Rider2
@@ -553,6 +556,7 @@ Note that you can toggle these effects at any time during the scenario by using 
         [/message]
         {UNIT 2 (EoMa_Cavalry_Archer) 21 16 (id=Rider3
         generate_name=yes)}
+        #wmllint: recognize Rider3
         {MOVE_UNIT id=Rider3 22 18}
         [message]
             speaker=Rider3
@@ -601,6 +605,7 @@ Note that you can toggle these effects at any time during the scenario by using 
         name="Amalrir"
         profile="portraits/tharis/greatwarlock.png"
         image_icon="portraits/tharis/greatwarlock.png~CROP(170,30,130,130)~SCALE(72,72)")}
+        #wmllint: recognize Warlock
         {CAPTURE_VILLAGES 4 6 3 8}
         [capture_village]
             side=1

--- a/scenarios/17_Siege_of_Kharos.cfg
+++ b/scenarios/17_Siege_of_Kharos.cfg
@@ -219,9 +219,11 @@
 
         {UNIT 6 (EoMa_Kirios) 8 9 (name,id= _ "Bodyguard",Bodyguard
         unrenamable=yes)}
+        #wmllint: recognize Bodyguard
 
         {UNIT 6 (EoMa_Golden_Warrior) 10 9 (id=Advisor
         name= _ "Advisor")}
+        #wmllint: recognize Advisor
 
         {UNIT 6 (EoMa_Platinum_Warrior) 19 2 (moves,max_moves=0,0)}
         {UNIT 6 (EoMa_Platinum_Warrior) 19 3 (moves,max_moves=0,0)}

--- a/scenarios/18_The_City_of_Light.cfg
+++ b/scenarios/18_The_City_of_Light.cfg
@@ -214,6 +214,7 @@
         {UNIT 1 (EoMa_Carpet_Rider) 25 12 (name= _ "Messenger"
         id=Messenger)}
         {SCROLL_TO 25 12}
+        #wmllint: recognize Messenger
 
         [message]
             speaker=Messenger
@@ -324,6 +325,9 @@
         {UNIT 3 (EoMa_Shadowmage) 5 8 (id=Agent1)}
         {UNIT 3 (EoMa_Shadowmage) 12 7 (id=Agent2)}
         {UNIT 3 (EoMa_Shadowmage) 21 8 (id=Agent3)}
+        #wmllint: recognize Agent1
+        #wmllint: recognize Agent2
+        #wmllint: recognize Agent3
 
         [message]
             speaker=Agent1

--- a/scenarios/19_Sky_Kingdom.cfg
+++ b/scenarios/19_Sky_Kingdom.cfg
@@ -313,6 +313,7 @@
             message= _ "Well, I am here because of that matter. I didn’t quite manage to join them on time. The Kharosians said you know how to get people there without circles. I hope you will offer me your aid."
         [/message]
         {UNIT 3 (EoMa_Shadowmage) () () (id,placement=Agent,leader)}
+        #wmllint: recognize Agent
         [message]
             speaker=Agent
             message= _ "It’s him."
@@ -653,6 +654,9 @@
         {UNIT 3 (EoMa_Um) 15 25 (id=Um)}
         {UNIT 3 (EoMa_Golem) 18 24 (id=golem1)}
         {UNIT 3 (EoMa_Golem) 18 25 (id=golem2)}
+        #wmllint: recognize Um
+        #wmllint: recognize golem1
+        #wmllint: recognize golem2
 
         #mehir's troops landing
         {TROOPS_LANDING 3 25 28}
@@ -873,6 +877,7 @@
         {TELEPORT_UNIT id=Rashti 17 19}
         {MODIFY_UNIT id=Rashti facing ne}
         {UNIT 3 (TLU_Magic_Mirror) 20 17 (id,facing=mirror,sw)}
+        #wmllint: recognize mirror
         {SCROLL_TO 20 17}
 
         {FADE_IN}
@@ -2089,7 +2094,7 @@
             [do]
                 [modify_unit]
                     [filter]
-                        id=this_item
+                        find_in=this_item
                     [/filter]
                     ai_special=none
                 [/modify_unit]

--- a/scenarios/20_Enlightenment.cfg
+++ b/scenarios/20_Enlightenment.cfg
@@ -240,6 +240,8 @@
     [/event]
 #enddef
 
+#wmllint: whofield TLU_LIBRARY_NPC 1
+
     {TLU_LIBRARY_NPC Mu EoMa_Mu facing=sw 19 9 (
         [message]
             speaker=Mehir

--- a/scenarios/21_Skydock.cfg
+++ b/scenarios/21_Skydock.cfg
@@ -56,6 +56,8 @@
         {UNIT 2 EoMa_Golem_Boss 20 8 (facing=sw)}
         {UNIT 2 EoMa_Golem_Boss 22 9 (facing=sw)}
         {UNIT 2 EoMa_Golem_Boss 24 10 (facing=sw)}
+        # wmllint: recognize Sculptor
+        # wmllint: recognize Void
     [/side]
 
     [side]
@@ -782,6 +784,8 @@
             random_name=yes)}
             {UNIT 2 EoMa_Elementalist 4 12 (id=mage2
             random_name=yes)}
+            #wmllint: recognize mage1
+            #wmllint: recognize mage2
 
             [message]
                 speaker=mage2
@@ -877,6 +881,9 @@
         {UNIT 2 EoMa_Mu 1 12 (id,name=Mu,"Mu N2565")}
         {UNIT 2 EoMa_Mu 1 12 (id,name=Mu2,"Mu N2257")}
         {UNIT 2 EoMa_Mu 1 12 (id,name=Mu3,"Mu N2681")}
+        #wmllint: recognize Mu
+        #wmllint: recognize Mu2
+        #wmllint: recognize Mu3
         {MOVE_UNIT type=EoMa_Mu 9 11}
         [message]
             speaker=Mu

--- a/scenarios/22_North_Pole.cfg
+++ b/scenarios/22_North_Pole.cfg
@@ -488,6 +488,7 @@
         animate=yes
         facing=se
         id=destroyer1)}
+        #wmllint: recognize destroyer1
         {SCROLL_TO 5 12}
         [delay]
             time=1000
@@ -679,7 +680,7 @@
             sound=hiss-hit.wav
         [/message]
         [message]
-            speaker=second unit
+            speaker=second_unit
             message= _ "Aaaaah!"
         [/message]
     [/event]

--- a/scenarios/23_Ruins.cfg
+++ b/scenarios/23_Ruins.cfg
@@ -1,5 +1,7 @@
 #textdomain wesnoth-To_Lands_Unknown
 
+# wmllint: recognize Glomin
+
 #define GUARDIANS_PACK1 TYPE
     {IF_VAR glomin_joins equals yes (
         [else]
@@ -338,7 +340,7 @@
 #define DEBUG_RUINS_CONDITION
     [set_menu_item]
         id=control_circle
-        description="Test Circle Area"
+        description=_ "Test Circle Area"
 
         [command]
             [if]
@@ -389,7 +391,7 @@
     [/set_menu_item]
     [set_menu_item]
         id=control_circle2
-        description="Show Circle Area"
+        description=_ "Show Circle Area"
 
         [command]
             [remove_shroud]
@@ -1984,10 +1986,12 @@ The order in which the spells are cast does not matter."
         {UNIT 4 (EoMa_Sorcerer) 24 14 (id=Mage
         name=_"Augurius"
         facing=se)}
+        # wmllint: recognize Mage
 
         {UNIT 4 (EoMa_Sculptor) 26 12 (id=Historian
         name=_"Antiquarius"
         facing=se)}
+        # wmllint: recognize Historian
 
         {BADASS_MODE_CHANGE (
             {UNIT 4 (TLU_animhack) 17 15 (variation,facing=golemball,se)}
@@ -2392,6 +2396,7 @@ The order in which the spells are cast does not matter."
         name=time over
 
         {UNIT 2 (EoMa_DarkApostle) 22 1 (id,animate=apostle,yes)}
+        #wmllint: recognize apostle
         {MOVE_UNIT id=apostle 22 6}
         {UNIT 2 (TLU_animhack) 19 10 (max_hitpoints=45,hitpoints=45)}
         [harm_unit]

--- a/scenarios/24_Epilogue.cfg
+++ b/scenarios/24_Epilogue.cfg
@@ -160,6 +160,10 @@
         name=_"Augurius"
         facing=se)}
 
+        #wmllint: recognize Historian
+        #wmllint: recognize Void
+        #wmllint: recognize Sorcerer
+
         {TLU_MAGI_FORMATION 13 EoMa_Void_Mage}
         {TLU_MAGI_FORMATION 12 EoMa_Sorcerer}
         {TLU_MAGI_FORMATION 11 EoMa_Sculptor}
@@ -254,6 +258,7 @@
             message= _ "Do not worry, Summoner. This is not the first time we created a wormhole to a different dimension. It is still a rather rare event given the fact it requires incredible amounts of energy to make it work, but we've attempted something like that several times in our history and never failed."
         [/message]
         {UNIT 2 EoMa_Mu 4 6 (id,name=Mu,"Mu N9898")}
+        #wmllint: recognize Mu
         {MOVE_UNIT id=Mu 8 6}
         [message]
             speaker=Mu

--- a/units/Salamander_Messenger.cfg
+++ b/units/Salamander_Messenger.cfg
@@ -17,7 +17,7 @@
     advances_to=null
     cost=30
     usage=healer
-    description="."
+    description=_ "description^Salamander Messenger."
     [movement_costs]
         shallow_water=99
         reef=99

--- a/units/animation_hack.cfg
+++ b/units/animation_hack.cfg
@@ -1931,13 +1931,13 @@
         ellipse=none
         [standing_anim]
             [frame]
-                image="terrain/gate2a/0025.jpg:1000"
+                image="terrain/gate2a/0025.jpg:1000" # no-syntax-rewrite
                 x=2
                 y=-33
                 auto_vflip=no
             [/frame]
             [second_frame]
-                image="terrain/gate2b/0025.png:1000"
+                image="terrain/gate2b/0025.png:1000" # no-syntax-rewrite
                 x=2
                 y=185
                 auto_vflip=no


### PR DESCRIPTION
Almost all are false positives that had to be suppressed, but two legitimate issues were found:
- [micro_ai] should have ca_id attribute, not id.
- S19 Cosmic Eyes unintendedly kept their Guardian status for the entire mission.