### PR TITLE
S23: Fixes to Fire/Summoners recruit locks

### DIFF
--- a/scenarios/23_Ruins.cfg
+++ b/scenarios/23_Ruins.cfg
@@ -439,6 +439,16 @@
             [/recall]
             {MOVE_UNIT x,y=19,28 19 23}
         )}
+        [store_unit]
+            [filter]
+                race=eoma_summoner
+                [not]
+                    x,y=recall,recall
+                [/not]
+            [/filter]
+            variable=mehirunits
+        [/store_unit]
+        {VARIABLE summoners $mehirunits.length}
         {CLEAR_VARIABLE mehirunits}
 
         {MODIFY_UNIT side=1 upkeep loyal}
@@ -568,33 +578,64 @@
         [/allow_undo]
 
         [filter]
-            id=Mehir
+            id=Mehir,Rashti
         [/filter]
 
         {IF_VAR turn_number equals 1 (
             [then]
-                {MODIFY_UNIT id=Mehir moves $mehirvar.max_moves}
+                {MODIFY_UNIT id=$unit.id moves $unit.max_moves}
             [/then]
         )}
     [/event]
+
+    # Turn 1: Prevent Mehir from wasting all his movement points in summoning.
+    # Also, prevent unlimited fast summons.
     [event]
-        name=moveto
+        # This should really be just try_summon, but the information of the summoned unit can only be passed in 1.17.
+        name=try summon EoMa_Air_Elemental,try summon EoMa_Earth_Elemental,try summon EoMa_Fire_Elemental,try summon EoMa_Water_Elemental,try summon EoMa_Rhami,try summon EoMa_RhamiKai,try summon EoMa_RhamiDatu
         first_time_only=no
-        [allow_undo]
-        [/allow_undo]
-
+        [filter_condition]
+            [variable]
+                name=turn_number
+                equals=1
+            [/variable]
+        [/filter_condition]
         [filter]
-            id=Rashti
+            [filter_wml]
+                [variables]
+                    summoned_first_turn=yes
+                [/variables]
+            [/filter_wml]
+            [or]
+                id=Mehir
+                [not]
+                    ability=eoma_fastsummon
+                [/not]
+            [/or]
         [/filter]
-
-        {IF_VAR turn_number equals 1 (
-            [then]
-                {MODIFY_UNIT id=Rashti moves $rashtivar.max_moves}
-            [/then]
-        )}
+        [message]
+            speaker=Mehir
+            message= _ "We’d better find this battery and get out of this freezing hellhole as soon as possible..."
+        [/message]
+        [return][/return]
     [/event]
 
-    #make summoned units loyal
+    [event]
+        name=post summon
+        first_time_only=no
+        [filter_condition]
+            [variable]
+                name=turn_number
+                equals=1
+            [/variable]
+        [/filter_condition]
+        [filter_second]
+            id=Mehir,Rashti
+        [/filter_second]
+        {MODIFY_UNIT (id=$second_unit.id) "variables.summoned_first_turn" "yes"}
+    [/event]
+
+    # make summoned units loyal
     [event]
         name=prerecruit,prerecall,post summon,post advance,post gate
         first_time_only=no
@@ -603,34 +644,76 @@
             side=1
         [/filter]
 
-        #summoners counter
-        [if]
-            [have_unit]
-                x,y=$x1,$y1
-                race=eoma_summoner
-            [/have_unit]
-            [then]
-                {VARIABLE_OP summoners add 1}
-                [if]
-                    [variable]
-                        name=summoners
-                        greater_than=39
-                    [/variable]
-                    [then]
-                        [disallow_recruit]
-                            side=1
-                            type=EoMa_Novice_Summoner,EoMa_Dispeller,EoMa_Camel_Rider,EoMa_Carpet_Rider,EoMa_Summoner,EoMa_Carpet_Master,EoMa_Heavy_Camel_Rider
-                        [/disallow_recruit]
-                        [message]
-                            speaker=Mehir
-                            message= _ "I can’t summon more men; there won’t be enough room for them inside the circle!"
-                        [/message]
-                    [/then]
-                [/if]
-            [/then]
-        [/if]
-
         {MODIFY_UNIT side=1 upkeep loyal}
+
+        [allow_undo]
+        [/allow_undo]
+    [/event]
+
+    # Event disallow_excess_summoners must be defined (and therefore executed) before
+    # summoners_counter, to ensure they won't interfere with each other.
+    [event]
+        name=prerecruit,prerecall
+        id=disallow_excess_summoners
+        first_time_only=no
+
+        [filter]
+            side=1
+            race=eoma_summoner
+        [/filter]
+        [filter_condition]
+            [variable]
+                name=summoners
+                equals=39 # Max 40 summoners (-1).
+            [/variable]
+        [/filter_condition]
+
+        {VARIABLE_OP summoners add 1} # Now, summoners=40 (max)
+
+        # Current recruit/recall succeeds. Disallow afterwards.
+        [disallow_recruit]
+            side=1
+            type=EoMa_Novice_Summoner,EoMa_Dispeller,EoMa_Camel_Rider,EoMa_Carpet_Rider,EoMa_Summoner,EoMa_Carpet_Master,EoMa_Heavy_Camel_Rider
+        [/disallow_recruit]
+        [store_unit]
+            [filter]
+                side=1
+                race=eoma_summoner
+                x,y=recall,recall
+            [/filter]
+            variable=summoners_recall_memo
+            mode=append
+            kill=yes
+        [/store_unit]
+        [message]
+            speaker=Mehir
+            message= _ "I can’t summon more men; there won’t be enough room for them inside the circle!"
+        [/message]
+    [/event]
+
+    [event]
+        name=prerecruit,prerecall
+        id=summoners_counter
+        first_time_only=no
+
+        [filter]
+            side=1
+            race=eoma_summoner
+        [/filter]
+        [filter_condition]
+            [variable]
+                name=summoners
+                less_than_equal_to=38 # Max 40 summoners (-2).
+            [/variable]
+        [/filter_condition]
+
+        {VARIABLE_OP summoners add 1} # summoners may be up to 39 now.
+
+        [allow_undo]
+        [/allow_undo]
+        [on_undo]
+            {VARIABLE_OP summoners sub 1}
+        [/on_undo]
     [/event]
 
     #summoners counter for the circle area
@@ -648,16 +731,20 @@
         [if]
             [variable]
                 name=summoners
-                greater_than=39
+                greater_than=39 # Max 40 summoners (-1).
             [/variable]
             [else]
                 [allow_recruit]
                     side=1
                     type=EoMa_Novice_Summoner,EoMa_Dispeller,EoMa_Camel_Rider,EoMa_Carpet_Rider,EoMa_Summoner,EoMa_Carpet_Master,EoMa_Heavy_Camel_Rider
                 [/allow_recruit]
+                [fire_event]
+                    name=restore_summoners_recalls
+                [/fire_event]
             [/else]
         [/if]
 
+        # If the summoner died outside, we may now be ready to evacuate.
         [if]
             [variable]
                 name=circle_complete
@@ -669,6 +756,21 @@
                 [/fire_event]
             [/then]
         [/if]
+    [/event]
+
+    [event]
+        name=restore_summoners_recalls
+        first_time_only=no
+        [foreach]
+            array=summoners_recall_memo
+            [do]
+                [unstore_unit]
+                    variable=this_item
+                    x,y=recall,recall
+                [/unstore_unit]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE summoners_recall_memo}
     [/event]
 
     #gate opened
@@ -946,8 +1048,6 @@ The order in which the spells are cast does not matter."
                     image=portraits/narrator.png
                     message= _ "After completing the circle, you will need to gather all your living troops and Rashti inside the circle. You cannot leave your men behind."
                 [/message]
-
-                {VARIABLE summoners 1}
 
                 {VARIABLE stages 0}
                 [objectives]
@@ -2217,6 +2317,14 @@ The order in which the spells are cast does not matter."
 
     [event]
         name=victory
+
+        [fire_event]
+            name=restore_fire_recalls
+        [/fire_event]
+        [fire_event]
+            name=restore_summoners_recalls
+        [/fire_event]
+
         {ENSURE_TRUE_RASHTI}
         {CLEAR_VARIABLE circle_phase1}
         {CLEAR_VARIABLE circle_phase2}
@@ -2631,6 +2739,12 @@ The order in which the spells are cast does not matter."
         [filter]
             type=EoMa_Fire_God,EoMa_Fire_Avatar,EoMa_Fire_Elemental
         [/filter]
+        [filter_condition]
+            [variable]
+                name=toohot
+                not_equals=yes
+            [/variable]
+        [/filter_condition]
 
         [if]
             [have_unit]
@@ -2650,6 +2764,7 @@ The order in which the spells are cast does not matter."
                         x,y=recall,recall
                     [/filter]
                     variable=fire_recall_memo
+                    mode=append
                     kill=yes
                 [/store_unit]
                 [fire_event]
@@ -2657,11 +2772,25 @@ The order in which the spells are cast does not matter."
                 [/fire_event]
             [/then]
         [/if]
+
+        # count=1 is likely to trigger advice, while count=3 blocks new summons.
+        # So, it'd would only be possible to allow undo for count=2,
+        # but that's not necessarily very intuitive.
+        #
+        # It'd also be a mess because "toohot" is also checked by DGATES_PAY2LVL.
+        # So allowing undo would require reworking "toohot" into "heatlevel",
+        # as it was intended at some point.
     [/event]
 
     [event]
         name=try summon EoMa_Fire_Elemental
         first_time_only=no
+        [filter_condition]
+            [variable]
+                name=turn_number
+                not_equals=1
+            [/variable]
+        [/filter_condition]
 
         [if]
             [have_unit]
@@ -2699,18 +2828,26 @@ The order in which the spells are cast does not matter."
                     side=1,5
                     type=EoMa_Fire_Avatar,EoMa_Fire_Elemental
                 [/allow_recruit]
-                [foreach]
-                    array=fire_recall_memo
-                    [do]
-                        [unstore_unit]
-                            variable=this_item
-                            x,y=recall,recall
-                        [/unstore_unit]
-                    [/do]
-                [/foreach]
-                {CLEAR_VARIABLE fire_recall_memo}
+                [fire_event]
+                    name=restore_fire_recalls
+                [/fire_event]
             [/else]
         [/if]
+    [/event]
+
+    [event]
+        name=restore_fire_recalls
+        first_time_only=no
+        [foreach]
+            array=fire_recall_memo
+            [do]
+                [unstore_unit]
+                    variable=this_item
+                    x,y=recall,recall
+                [/unstore_unit]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE fire_recall_memo}
     [/event]
 
     [event]


### PR DESCRIPTION
- Fire comment was spammed on MOVE_UNIT calls in turn 1.
- It was possible for the fire_recall_memo array to be emptied prematurely. This is now avoided by storing units to it with mode=append.
- Recalling summoners was not disallowed at all.
- Summoners automatically recalled from S22 were not counted.
- Recalling summoners can now almost always be undone.